### PR TITLE
fix: update repo links to use bluetooth-devices

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ["bdraco"]
+github: ["bluetooth-devices"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,114 +4,114 @@
 
 ### Features
 
-- Change license to apache-2.0 (#61) ([`16f5a1b`](https://github.com/bdraco/aiodhcpwatcher/commit/16f5a1b3bf96526d5f745bcd0aac33ae408e68fc))
+- Change license to apache-2.0 (#61) ([`16f5a1b`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/16f5a1b3bf96526d5f745bcd0aac33ae408e68fc))
 
 ## v1.0.4 (2025-02-04)
 
 ### Bug fixes
 
-- Update poetry to v2 + add license to metadata (#60) ([`52c6e80`](https://github.com/bdraco/aiodhcpwatcher/commit/52c6e8002d98b9960705fa0ea246099e3b62eeeb))
+- Update poetry to v2 + add license to metadata (#60) ([`52c6e80`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/52c6e8002d98b9960705fa0ea246099e3b62eeeb))
 
 ## v1.0.3 (2025-02-02)
 
 ### Bug fixes
 
-- Handle network being temporarily unavailable (#57) ([`55d24dc`](https://github.com/bdraco/aiodhcpwatcher/commit/55d24dcd11cdf22a9a6bf4489e2b8a2791638f0e))
+- Handle network being temporarily unavailable (#57) ([`55d24dc`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/55d24dcd11cdf22a9a6bf4489e2b8a2791638f0e))
 
 ## v1.0.2 (2024-06-24)
 
 ### Bug fixes
 
-- Licensing classifier (#21) ([`bdfa9ef`](https://github.com/bdraco/aiodhcpwatcher/commit/bdfa9ef9bc3cbb1fecbf6a5848615e5fd2e619fb))
+- Licensing classifier (#21) ([`bdfa9ef`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/bdfa9ef9bc3cbb1fecbf6a5848615e5fd2e619fb))
 
 ## v1.0.1 (2024-03-15)
 
 ### Bug fixes
 
-- Update readme example for breaking changes in 1.0.0 (#19) ([`fd53e64`](https://github.com/bdraco/aiodhcpwatcher/commit/fd53e64b64f74af02c68e7e13261cbf23370be11))
+- Update readme example for breaking changes in 1.0.0 (#19) ([`fd53e64`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/fd53e64b64f74af02c68e7e13261cbf23370be11))
 
 ## v1.0.0 (2024-03-14)
 
 ### Bug fixes
 
-- Run scapy filter creation in the executor (#17) ([`e5965d3`](https://github.com/bdraco/aiodhcpwatcher/commit/e5965d335b8e02745ab727acef34bbb96f6a6076))
+- Run scapy filter creation in the executor (#17) ([`e5965d3`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/e5965d335b8e02745ab727acef34bbb96f6a6076))
 
 ## v0.8.2 (2024-03-14)
 
 ### Bug fixes
 
-- Ensure all scapy modules are loaded in the executor (#16) ([`694c831`](https://github.com/bdraco/aiodhcpwatcher/commit/694c83121995ee756a50ef158be71bf50a600f65))
+- Ensure all scapy modules are loaded in the executor (#16) ([`694c831`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/694c83121995ee756a50ef158be71bf50a600f65))
 
 ## v0.8.1 (2024-03-11)
 
 ### Bug fixes
 
-- Add a guard for when the options tuple is only one item (#15) ([`37a7371`](https://github.com/bdraco/aiodhcpwatcher/commit/37a7371693f693871947638bf85c69d7a1636bc1))
+- Add a guard for when the options tuple is only one item (#15) ([`37a7371`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/37a7371693f693871947638bf85c69d7a1636bc1))
 
 ## v0.8.0 (2024-02-09)
 
 ### Features
 
-- Add support for setting nonblock with pcap (#14) ([`3287b50`](https://github.com/bdraco/aiodhcpwatcher/commit/3287b500ab4dc546257cdcb144746f7d8fa1d37c))
+- Add support for setting nonblock with pcap (#14) ([`3287b50`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/3287b500ab4dc546257cdcb144746f7d8fa1d37c))
 
 ## v0.7.0 (2024-02-09)
 
 ### Features
 
-- Add helper to load scapy in the executor since it can block the loop (#13) ([`0ec1983`](https://github.com/bdraco/aiodhcpwatcher/commit/0ec19835ccd52e5c71c5d15c5e48c0382b4aea4f))
+- Add helper to load scapy in the executor since it can block the loop (#13) ([`0ec1983`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/0ec19835ccd52e5c71c5d15c5e48c0382b4aea4f))
 
 ## v0.6.0 (2024-02-08)
 
 ### Features
 
-- Add test coverage for broken filtering (#12) ([`c23d934`](https://github.com/bdraco/aiodhcpwatcher/commit/c23d934e6f86c031bb25a309edaff607b255596d))
+- Add test coverage for broken filtering (#12) ([`c23d934`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/c23d934e6f86c031bb25a309edaff607b255596d))
 
 ## v0.5.0 (2024-02-08)
 
 ### Features
 
-- Decode hostnames using idna encoding (#10) ([`111cdfe`](https://github.com/bdraco/aiodhcpwatcher/commit/111cdfefcfc621c7ef3d001d8b9f8e2b85460ef2))
+- Decode hostnames using idna encoding (#10) ([`111cdfe`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/111cdfefcfc621c7ef3d001d8b9f8e2b85460ef2))
 
 ## v0.4.0 (2024-02-08)
 
 ### Features
 
-- Increase coverage (#9) ([`6280898`](https://github.com/bdraco/aiodhcpwatcher/commit/6280898a4a55cc3e0feed3e6b78c453038419c5e))
+- Increase coverage (#9) ([`6280898`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/6280898a4a55cc3e0feed3e6b78c453038419c5e))
 
 ## v0.3.3 (2024-02-08)
 
 ### Bug fixes
 
-- Add checks for perm error setting up reader (#8) ([`58b4025`](https://github.com/bdraco/aiodhcpwatcher/commit/58b40253abcefb71deb17c7d87c706a3f47f15fe))
+- Add checks for perm error setting up reader (#8) ([`58b4025`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/58b40253abcefb71deb17c7d87c706a3f47f15fe))
 
 ## v0.3.2 (2024-02-08)
 
 ### Bug fixes
 
-- Ensure filter can be created on macos (#7) ([`8c00359`](https://github.com/bdraco/aiodhcpwatcher/commit/8c0035964b249eeedc684f19794a99d93a3317a0))
+- Ensure filter can be created on macos (#7) ([`8c00359`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/8c0035964b249eeedc684f19794a99d93a3317a0))
 
 ## v0.3.1 (2024-02-08)
 
 ### Bug fixes
 
-- Import order (#6) ([`3acbb20`](https://github.com/bdraco/aiodhcpwatcher/commit/3acbb202a4cbfee1fa41595ac5b746c485c1c04e))
+- Import order (#6) ([`3acbb20`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/3acbb202a4cbfee1fa41595ac5b746c485c1c04e))
 
 ## v0.3.0 (2024-02-08)
 
 ### Features
 
-- Refactor to make more testable (#4) ([`ddd6d84`](https://github.com/bdraco/aiodhcpwatcher/commit/ddd6d84c8246b05384b92fa7edf45fca5bed6a92))
+- Refactor to make more testable (#4) ([`ddd6d84`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/ddd6d84c8246b05384b92fa7edf45fca5bed6a92))
 
 ## v0.2.0 (2024-02-08)
 
 ### Features
 
-- Cleanups (#2) ([`fdfd1b6`](https://github.com/bdraco/aiodhcpwatcher/commit/fdfd1b66fc11a20930c8a869bcb8766c0156cb8c))
+- Cleanups (#2) ([`fdfd1b6`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/fdfd1b66fc11a20930c8a869bcb8766c0156cb8c))
 
 ## v0.1.0 (2024-02-08)
 
 ### Features
 
-- Init (#1) ([`188b4b3`](https://github.com/bdraco/aiodhcpwatcher/commit/188b4b315ce3303cdeab9eeb8fa8f8eed2e185ec))
+- Init (#1) ([`188b4b3`](https://github.com/bluetooth-devices/aiodhcpwatcher/commit/188b4b315ce3303cdeab9eeb8fa8f8eed2e185ec))
 
 ## v0.0.0 (2024-02-08)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ $ pytest tests
 
 The deployment should be automated and can be triggered from the Semantic Release workflow in GitHub. The next version will be based on [the commit logs](https://python-semantic-release.readthedocs.io/en/latest/commit-log-parsing.html#commit-log-parsing). This is done by [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/index.html) via a GitHub action.
 
-[gh-issues]: https://github.com/bdraco/aiodhcpwatcher/issues
+[gh-issues]: https://github.com/bluetooth-devices/aiodhcpwatcher/issues

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # aiodhcpwatcher
 
 <p align="center">
-  <a href="https://github.com/bdraco/aiodhcpwatcher/actions/workflows/ci.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/bdraco/aiodhcpwatcher/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
+  <a href="https://github.com/bluetooth-devices/aiodhcpwatcher/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/bluetooth-devices/aiodhcpwatcher/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
   <a href="https://aiodhcpwatcher.readthedocs.io">
     <img src="https://img.shields.io/readthedocs/aiodhcpwatcher.svg?logo=read-the-docs&logoColor=fff&style=flat-square" alt="Documentation Status">
   </a>
-  <a href="https://codecov.io/gh/bdraco/aiodhcpwatcher">
-    <img src="https://img.shields.io/codecov/c/github/bdraco/aiodhcpwatcher.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
+  <a href="https://codecov.io/gh/bluetooth-devices/aiodhcpwatcher">
+    <img src="https://img.shields.io/codecov/c/github/bluetooth-devices/aiodhcpwatcher.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
   </a>
 </p>
 <p align="center">
@@ -34,7 +34,7 @@
 
 **Documentation**: <a href="https://aiodhcpwatcher.readthedocs.io" target="_blank">https://aiodhcpwatcher.readthedocs.io </a>
 
-**Source Code**: <a href="https://github.com/bdraco/aiodhcpwatcher" target="_blank">https://github.com/bdraco/aiodhcpwatcher </a>
+**Source Code**: <a href="https://github.com/bluetooth-devices/aiodhcpwatcher" target="_blank">https://github.com/bluetooth-devices/aiodhcpwatcher </a>
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ requires-python = ">=3.10"
 dynamic = ["classifiers", "dependencies", "optional-dependencies"]
 
 [project.urls]
-"Repository" = "https://github.com/bdraco/aiodhcpwatcher"
+"Repository" = "https://github.com/bluetooth-devices/aiodhcpwatcher"
 "Documentation" = "https://aiodhcpwatcher.readthedocs.io"
-"Bug Tracker" = "https://github.com/bdraco/aiodhcpwatcher/issues"
-"Changelog" = "https://github.com/bdraco/aiodhcpwatcher/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/bluetooth-devices/aiodhcpwatcher/issues"
+"Changelog" = "https://github.com/bluetooth-devices/aiodhcpwatcher/blob/main/CHANGELOG.md"
 
 [tool.poetry]
 classifiers = [


### PR DESCRIPTION
I have been transferring some of the projects that are under my person GitHub to OHF repos since it was hard for other contributors to help out with projects that were hosted on my personal GitHub. Bluetooth-devices has a lot of people I trust so I picked that org even though the fit is a bit strange.  We could later transfer it to home-assistant-libs if desired.