### PR TITLE
fix: update format string as if_index may be a string on some platforms

### DIFF
--- a/src/aiodhcpwatcher/__init__.py
+++ b/src/aiodhcpwatcher/__init__.py
@@ -186,10 +186,10 @@ class AIODHCPWatcher:
                 self._loop.add_reader(
                     fileno, partial(self._on_data, _handle_dhcp_packet, sock)
                 )
-                _LOGGER.debug("Started watching for dhcp packets on %d", if_index)
+                _LOGGER.debug("Started watching for dhcp packets on %s", if_index)
             except PermissionError as ex:
                 _LOGGER.error(
-                    "Permission denied to watch for dhcp packets on %d: %s",
+                    "Permission denied to watch for dhcp packets on %s: %s",
                     if_index,
                     ex,
                 )


### PR DESCRIPTION
fixes
```
Aug 09 23:23:27 homeassistant homeassistant[630]: TypeError: %d format: a real number is required, not builtin_function_or_method
Aug 09 23:23:27 homeassistant homeassistant[630]: Call stack:
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "<frozen runpy>", line 198, in _run_module_as_main
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "<frozen runpy>", line 88, in _run_code
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/src/homeassistant/homeassistant/__main__.py", line 223, in <module>
Aug 09 23:23:27 homeassistant homeassistant[630]:     sys.exit(main())
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/src/homeassistant/homeassistant/__main__.py", line 209, in main
Aug 09 23:23:27 homeassistant homeassistant[630]:     exit_code = runner.run(runtime_conf)
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/src/homeassistant/homeassistant/runner.py", line 156, in run
Aug 09 23:23:27 homeassistant homeassistant[630]:     return loop.run_until_complete(setup_and_run_hass(runtime_config))
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/local/lib/python3.13/asyncio/base_events.py", line 706, in run_until_complete
Aug 09 23:23:27 homeassistant homeassistant[630]:     self.run_forever()
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/local/lib/python3.13/asyncio/base_events.py", line 677, in run_forever
Aug 09 23:23:27 homeassistant homeassistant[630]:     self._run_once()
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2034, in _run_once
Aug 09 23:23:27 homeassistant homeassistant[630]:     handle._run()
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
Aug 09 23:23:27 homeassistant homeassistant[630]:     self._context.run(self._callback, *self._args)
Aug 09 23:23:27 homeassistant homeassistant[630]:   File "/usr/src/homeassistant/homeassistant/components/dhcp/__init__.py", line 151, in _async_initialize
```