### PR TITLE
fix(lint): repair ruff and mypy after autoupdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,135 +1,141 @@
 # Changelog
 
+## v1.2.2-rc.1 (2026-05-24)
+
+### Bug fixes
+
+- Bump ruff target to py310 and move lint settings under [tool.ruff.lint] ([`e77a1f6`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/e77a1f69c6b8874da9c6b6a554896e5369243791))
+
 ## v1.2.1 (2025-08-12)
 
 ### Bug fixes
 
-- Update format string as if_index may be a string on some platforms (#94) ([`4fb0474`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/4fb04742e28dc986cc6ee44ee015bcf237d2011d))
+- Update format string as if_index may be a string on some platforms ([`4fb0474`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/4fb04742e28dc986cc6ee44ee015bcf237d2011d))
 
 ## v1.2.0 (2025-05-12)
 
 ### Features
 
-- Add option to select multiple interfaces (#83) ([`69019b4`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/69019b43a8c96a6ffc947219373fa2e14587c8da))
+- Add option to select multiple interfaces ([`69019b4`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/69019b43a8c96a6ffc947219373fa2e14587c8da))
 
 ## v1.1.1 (2025-02-22)
 
 ### Bug fixes
 
-- Update repo links to use bluetooth-devices (#64) ([`1effe3f`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/1effe3fcfbfcb5c2310343930ccde4a400e34de7))
+- Update repo links to use bluetooth-devices ([`1effe3f`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/1effe3fcfbfcb5c2310343930ccde4a400e34de7))
 
 ## v1.1.0 (2025-02-04)
 
 ### Features
 
-- Change license to apache-2.0 (#61) ([`16f5a1b`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/16f5a1b3bf96526d5f745bcd0aac33ae408e68fc))
+- Change license to apache-2.0 ([`16f5a1b`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/16f5a1b3bf96526d5f745bcd0aac33ae408e68fc))
 
 ## v1.0.4 (2025-02-04)
 
 ### Bug fixes
 
-- Update poetry to v2 + add license to metadata (#60) ([`52c6e80`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/52c6e8002d98b9960705fa0ea246099e3b62eeeb))
+- Update poetry to v2 + add license to metadata ([`52c6e80`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/52c6e8002d98b9960705fa0ea246099e3b62eeeb))
 
 ## v1.0.3 (2025-02-02)
 
 ### Bug fixes
 
-- Handle network being temporarily unavailable (#57) ([`55d24dc`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/55d24dcd11cdf22a9a6bf4489e2b8a2791638f0e))
+- Handle network being temporarily unavailable ([`55d24dc`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/55d24dcd11cdf22a9a6bf4489e2b8a2791638f0e))
 
 ## v1.0.2 (2024-06-24)
 
 ### Bug fixes
 
-- Licensing classifier (#21) ([`bdfa9ef`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/bdfa9ef9bc3cbb1fecbf6a5848615e5fd2e619fb))
+- Licensing classifier ([`bdfa9ef`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/bdfa9ef9bc3cbb1fecbf6a5848615e5fd2e619fb))
 
 ## v1.0.1 (2024-03-15)
 
 ### Bug fixes
 
-- Update readme example for breaking changes in 1.0.0 (#19) ([`fd53e64`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/fd53e64b64f74af02c68e7e13261cbf23370be11))
+- Update readme example for breaking changes in 1.0.0 ([`fd53e64`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/fd53e64b64f74af02c68e7e13261cbf23370be11))
 
 ## v1.0.0 (2024-03-14)
 
 ### Bug fixes
 
-- Run scapy filter creation in the executor (#17) ([`e5965d3`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/e5965d335b8e02745ab727acef34bbb96f6a6076))
+- Run scapy filter creation in the executor ([`e5965d3`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/e5965d335b8e02745ab727acef34bbb96f6a6076))
 
 ## v0.8.2 (2024-03-14)
 
 ### Bug fixes
 
-- Ensure all scapy modules are loaded in the executor (#16) ([`694c831`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/694c83121995ee756a50ef158be71bf50a600f65))
+- Ensure all scapy modules are loaded in the executor ([`694c831`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/694c83121995ee756a50ef158be71bf50a600f65))
 
 ## v0.8.1 (2024-03-11)
 
 ### Bug fixes
 
-- Add a guard for when the options tuple is only one item (#15) ([`37a7371`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/37a7371693f693871947638bf85c69d7a1636bc1))
+- Add a guard for when the options tuple is only one item ([`37a7371`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/37a7371693f693871947638bf85c69d7a1636bc1))
 
 ## v0.8.0 (2024-02-09)
 
 ### Features
 
-- Add support for setting nonblock with pcap (#14) ([`3287b50`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/3287b500ab4dc546257cdcb144746f7d8fa1d37c))
+- Add support for setting nonblock with pcap ([`3287b50`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/3287b500ab4dc546257cdcb144746f7d8fa1d37c))
 
 ## v0.7.0 (2024-02-09)
 
 ### Features
 
-- Add helper to load scapy in the executor since it can block the loop (#13) ([`0ec1983`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/0ec19835ccd52e5c71c5d15c5e48c0382b4aea4f))
+- Add helper to load scapy in the executor since it can block the loop ([`0ec1983`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/0ec19835ccd52e5c71c5d15c5e48c0382b4aea4f))
 
 ## v0.6.0 (2024-02-08)
 
 ### Features
 
-- Add test coverage for broken filtering (#12) ([`c23d934`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/c23d934e6f86c031bb25a309edaff607b255596d))
+- Add test coverage for broken filtering ([`c23d934`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/c23d934e6f86c031bb25a309edaff607b255596d))
 
 ## v0.5.0 (2024-02-08)
 
 ### Features
 
-- Decode hostnames using idna encoding (#10) ([`111cdfe`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/111cdfefcfc621c7ef3d001d8b9f8e2b85460ef2))
+- Decode hostnames using idna encoding ([`111cdfe`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/111cdfefcfc621c7ef3d001d8b9f8e2b85460ef2))
 
 ## v0.4.0 (2024-02-08)
 
 ### Features
 
-- Increase coverage (#9) ([`6280898`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/6280898a4a55cc3e0feed3e6b78c453038419c5e))
+- Increase coverage ([`6280898`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/6280898a4a55cc3e0feed3e6b78c453038419c5e))
 
 ## v0.3.3 (2024-02-08)
 
 ### Bug fixes
 
-- Add checks for perm error setting up reader (#8) ([`58b4025`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/58b40253abcefb71deb17c7d87c706a3f47f15fe))
+- Add checks for perm error setting up reader ([`58b4025`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/58b40253abcefb71deb17c7d87c706a3f47f15fe))
 
 ## v0.3.2 (2024-02-08)
 
 ### Bug fixes
 
-- Ensure filter can be created on macos (#7) ([`8c00359`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/8c0035964b249eeedc684f19794a99d93a3317a0))
+- Ensure filter can be created on macos ([`8c00359`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/8c0035964b249eeedc684f19794a99d93a3317a0))
 
 ## v0.3.1 (2024-02-08)
 
 ### Bug fixes
 
-- Import order (#6) ([`3acbb20`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/3acbb202a4cbfee1fa41595ac5b746c485c1c04e))
+- Import order ([`3acbb20`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/3acbb202a4cbfee1fa41595ac5b746c485c1c04e))
 
 ## v0.3.0 (2024-02-08)
 
 ### Features
 
-- Refactor to make more testable (#4) ([`ddd6d84`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/ddd6d84c8246b05384b92fa7edf45fca5bed6a92))
+- Refactor to make more testable ([`ddd6d84`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/ddd6d84c8246b05384b92fa7edf45fca5bed6a92))
 
 ## v0.2.0 (2024-02-08)
 
 ### Features
 
-- Cleanups (#2) ([`fdfd1b6`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/fdfd1b66fc11a20930c8a869bcb8766c0156cb8c))
+- Cleanups ([`fdfd1b6`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/fdfd1b66fc11a20930c8a869bcb8766c0156cb8c))
 
 ## v0.1.0 (2024-02-08)
 
 ### Features
 
-- Init (#1) ([`188b4b3`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/188b4b315ce3303cdeab9eeb8fa8f8eed2e185ec))
+- Init ([`188b4b3`](https://github.com/Bluetooth-Devices/aiodhcpwatcher/commit/188b4b315ce3303cdeab9eeb8fa8f8eed2e185ec))
 
 ## v0.0.0 (2024-02-08)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 project = "aiodhcpwatcher"
 copyright = "2024, J. Nick Koston"
 author = "J. Nick Koston"
-release = "1.2.1"
+release = "1.2.2-rc.1"
 
 # General configuration
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,9 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 88
-ignore = [
+lint.ignore = [
     "D203", # 1 blank line required before class docstring
     "D212", # Multi-line docstring summary should start at the first line
     "D100", # Missing docstring in public module
@@ -95,7 +95,7 @@ ignore = [
     "D107", # Missing docstring in `__init__`
     "D401", # First line of docstring should be in imperative mood
 ]
-select = [
+lint.select = [
     "B",   # flake8-bugbear
     "D",   # flake8-docstrings
     "C4",  # flake8-comprehensions
@@ -108,7 +108,7 @@ select = [
     "RUF", # ruff specific
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/**/*" = [
     "D100",
     "D101",
@@ -121,7 +121,7 @@ select = [
 "conftest.py" = ["D100"]
 "docs/conf.py" = ["D100"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["aiodhcpwatcher", "tests"]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiodhcpwatcher"
-version = "1.2.1"
+version = "1.2.2-rc.1"
 license = "Apache-2.0"
 description = "Watch for DHCP packets with asyncio"
 authors = [{ name = "J. Nick Koston", email = "nick@koston.org" }]
@@ -13,6 +13,7 @@ dynamic = ["classifiers", "dependencies", "optional-dependencies"]
 "Documentation" = "https://aiodhcpwatcher.readthedocs.io"
 "Bug Tracker" = "https://github.com/bluetooth-devices/aiodhcpwatcher/issues"
 "Changelog" = "https://github.com/bluetooth-devices/aiodhcpwatcher/blob/main/CHANGELOG.md"
+
 
 [tool.poetry]
 classifiers = [
@@ -146,6 +147,7 @@ allow_untyped_defs = true
 [[tool.mypy.overrides]]
 module = "docs.*"
 ignore_errors = true
+
 
 [build-system]
 requires = ["poetry-core>=2.0.0"]

--- a/src/aiodhcpwatcher/__init__.py
+++ b/src/aiodhcpwatcher/__init__.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 import os
 import socket
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any
 
 from scapy.config import conf
 from scapy.error import Scapy_Exception
@@ -45,7 +46,7 @@ def make_packet_handler(
         if not (dhcp_packet := packet.getlayer(DHCP)):
             return
 
-        options: Iterable[tuple[str, int | bytes | None]] = dhcp_packet.options
+        options: Iterable[tuple[str, int | bytes | None] | str] = dhcp_packet.options
 
         options_dict: dict[str, int | bytes | None] = {}
         for option in options:

--- a/src/aiodhcpwatcher/__init__.py
+++ b/src/aiodhcpwatcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.1"
+__version__ = "1.2.2-rc.1"
 
 import asyncio
 import logging


### PR DESCRIPTION
Ruff started rejecting parenthesized with statements because the target version was still py38 even though the project requires 3.10+; bumping it to py310 fixes that, and the lint table keys are moved under [tool.ruff.lint] so the deprecation warning goes away too.

The mypy unreachable error came from the DHCP options annotation only listing tuples, while scapy actually yields the literal "end" string as a sentinel, so widening the type makes the break reachable again.